### PR TITLE
Use 'rails' option for SimpleCov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start('rails')
 
 require 'rspec/its'
 require 'pry'


### PR DESCRIPTION
The built-in 'rails' option for SimpleCov will test only our files in the lib directory. Prior to this, the spec files were also getting included in the coverage report, which they should not.