### PR TITLE
Report virus scans to a calling application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tmp
 coverage
 cc-test-reporter
 vendor
+/log/*
+!/log/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'activejob', '~> 6.0'
 gem 'aws-sdk-s3', '~> 1.60'
 gem 'clamby', '~> 1.6'
 gem 'ddtrace', '~> 0.36'
+gem 'faraday'
 gem 'http'
 gem 'nokogiri', '~> 1.10'
 gem 'ruby_tika_app', '~> 1.9'
@@ -23,6 +24,8 @@ gem 'pry'
 gem 'rspec', '~> 3.9'
 gem 'rspec-its', '~> 1.3'
 gem 'simplecov', '0.17.1', require: false
+gem 'vcr', require: false
+gem 'webmock', require: false
 
 # Niftany needs to be update to work with version 0.84 and later
 gem 'rubocop', '< 0.84'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     ddtrace (0.36.0)
       msgpack
@@ -64,6 +66,8 @@ GEM
       rubocop (~> 0.79)
       smart_properties
     erubi (1.9.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.13.0)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -85,6 +89,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (1.0.1)
     html_tokenizer (0.0.7)
     http (4.4.1)
       addressable (~> 2.3)
@@ -111,6 +116,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
+    multipart-post (2.1.1)
     nenv (0.3.0)
     niftany (0.8.0)
       colorize (~> 0.8.1)
@@ -182,6 +188,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_tika_app (1.9.0)
       open4
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -209,6 +216,11 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    vcr (6.0.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     zeitwerk (2.3.0)
 
 PLATFORMS
@@ -219,6 +231,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.60)
   clamby (~> 1.6)
   ddtrace (~> 0.36)
+  faraday
   guard (~> 2.16)
   guard-rspec (~> 4.7)
   http
@@ -231,6 +244,8 @@ DEPENDENCIES
   ruby_tika_app (~> 1.9)
   sidekiq (~> 6.0)
   simplecov (= 0.17.1)
+  vcr
+  webmock
 
 BUNDLED WITH
    2.1.4

--- a/lib/metadata_listener.rb
+++ b/lib/metadata_listener.rb
@@ -7,4 +7,16 @@ module MetadataListener
   require 'metadata_listener/fits_utils'
   require 'metadata_listener/tika'
   require 'metadata_listener/clamav_service'
+  require 'metadata_listener/virus_reporting_service'
+
+  class << self
+    # @note Because this is intended to run inside a Docker container, it is customary to write logs to STDOUT
+    def logger
+      @logger ||= Logger.new(STDOUT)
+    end
+
+    def s3_client
+      @s3_client ||= S3Client.new
+    end
+  end
 end

--- a/lib/metadata_listener/clamav_service.rb
+++ b/lib/metadata_listener/clamav_service.rb
@@ -4,14 +4,12 @@ require 'clamby'
 
 module MetadataListener
   class ClamavService
-    # @param [String, Pathname] filename path of file to scan
-    def self.call(filename)
-      path = filename.is_a?(String) ? Pathname.new(filename) : filename
-
-      return false unless path.exist?
+    # @param [String] path of file to scan
+    def self.call(path)
+      return false unless Pathname.new(path).exist?
 
       Clamby.configure(daemonize: false)
-      Clamby.virus?(path.to_s)
+      Clamby.virus?(path)
     end
   end
 end

--- a/lib/metadata_listener/virus_reporting_service.rb
+++ b/lib/metadata_listener/virus_reporting_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module MetadataListener
+  class VirusReportingService
+    def self.call(**args)
+      new(args[:path], args[:endpoint], args[:api_token]).send
+    end
+
+    attr_reader :path, :endpoint, :api_token
+
+    def initialize(path, endpoint, api_token)
+      @path = path
+      @endpoint = endpoint
+      @api_token = api_token
+    end
+
+    def send
+      log_results
+      report_results if endpoint.present?
+    end
+
+    private
+
+      def log_results
+        if virus?
+          MetadataListener.logger.fatal("!!! Virus FOUND for #{path}")
+        else
+          MetadataListener.logger.info("No virus found for #{path}")
+        end
+      end
+
+      # @return [TrueClass,FalseClass]
+      def virus?
+        return @virus unless @virus.nil?
+
+        @virus = ClamavService.call(path)
+      end
+
+      def report_results
+        response = connection.put do |req|
+          req.body = { metadata: { virus: { status: virus?, scanned_at: Time.now } } }.to_json
+        end
+        MetadataListener.logger.warn("Report failed: #{response.body}") unless response.success?
+      end
+
+      def connection
+        @connection ||= Faraday::Connection.new(
+          url: endpoint,
+          headers: {
+            'Content-Type' => 'application/json',
+            'X-API-KEY' => api_token
+          },
+          ssl: { verify: verify_ssl? }
+        )
+      end
+
+      def verify_ssl?
+        ENV['VERIFY_CLIENT_SSL'] != 'false'
+      end
+  end
+end

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+$LOAD_PATH.prepend(Pathname.pwd.join('lib').to_s)
 require 'sidekiq'
-require_relative './lib/metadata_listener/redis'
+require 'metadata_listener'
 
 ::Sidekiq.configure_client do |config|
   config.redis = MetadataListener::Redis.config
@@ -13,10 +14,12 @@ end
 
 if ENV['DD_AGENT_HOST']
   require 'ddtrace'
-  Datadog.configure do |c|
-    c.use :sidekiq, { analytics_enabled: true,
-                      service_name: 'scholarsphere-metadata-listener' }
-    c.use :redis
-    c.tracer env: ENV['DD_ENV']
+  Datadog.configure do |config|
+    config.use :sidekiq, {
+      analytics_enabled: true,
+      service_name: 'scholarsphere-metadata-listener'
+    }
+    config.use :redis
+    config.tracer env: ENV['DD_ENV']
   end
 end

--- a/spec/fixtures/vcr_cassettes/MetadataListener_VirusReportingService/when_reporting_results/sends_the_results_to_an_endpoint.yml
+++ b/spec/fixtures/vcr_cassettes/MetadataListener_VirusReportingService/when_reporting_results/sends_the_results_to_an_endpoint.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://scholarsphere-4.test/api/v1/metadata/1
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"virus":{"status":false,"scanned_at":"2020-06-16 21:57:32
+        -0400"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - xxxxxx
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"dc26fdcdd57abac4c20b12f6635117e7"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - e8c4065b-4bb2-475d-a6ba-2e37af6e569c
+      X-Runtime:
+      - '0.010555'
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 17 Jun 2020 01:57:33 GMT
+      Content-Length:
+      - '43'
+    body:
+      encoding: UTF-8
+      string: '{"message":"File was successfully updated"}'
+  recorded_at: Wed, 17 Jun 2020 01:57:33 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/MetadataListener_VirusReportingService/when_unable_to_report_results/logs_the_response_from_the_endpoint.yml
+++ b/spec/fixtures/vcr_cassettes/MetadataListener_VirusReportingService/when_unable_to_report_results/logs_the_response_from_the_endpoint.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://scholarsphere-4.test/api/v1/metadata/1
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"virus":{"status":false,"scanned_at":"2020-06-17 15:19:38
+        -0400"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - d40221f7-2adb-430a-8bf1-45f7d683edb9
+      X-Runtime:
+      - '0.166863'
+      X-Xss-Protection:
+      - 1; mode=block
+      Date:
+      - Wed, 17 Jun 2020 19:19:53 GMT
+      Content-Length:
+      - '96'
+    body:
+      encoding: UTF-8
+      string: '{"message":"401: Request not authorized. Please provide a valid API
+        key for access.","code":401}'
+  recorded_at: Wed, 17 Jun 2020 19:19:53 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/metadata_listener/clamav_service_spec.rb
+++ b/spec/lib/metadata_listener/clamav_service_spec.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe MetadataListener::ClamavService do
-  subject { described_class.call(file) }
+  subject { described_class.call(path) }
 
   context 'when a virus is not present' do
-    let(:file) { fixture_path.join('1.pdf') }
+    let(:path) { fixture_path.join('1.pdf').to_s }
 
     it { is_expected.to be(false) }
   end
 
   context 'when a virus is present' do
-    let(:file) { fixture_path.join('eicar_com.zip') }
+    let(:path) { fixture_path.join('eicar_com.zip').to_s }
 
     it { is_expected.to be(true) }
   end
 
   context 'when the path does not exist' do
-    let(:file) { 'nothere' }
+    let(:path) { 'nothere' }
 
     it { is_expected.to be(false) }
   end

--- a/spec/lib/metadata_listener/job_spec.rb
+++ b/spec/lib/metadata_listener/job_spec.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe MetadataListener::Job do
-  it do
-    skip 'Minio instance required for testing'
-    expect(described_class.new).to be_an(ActiveJob::Base)
+  it { is_expected.to be_an(ActiveJob::Base) }
+
+  context 'when everything goes according to plan' do
+    let(:path) { upload_file(file: fixture_path.join('1.pdf')) }
+
+    it 'downloads the file and call the VirusReportingService' do
+      allow(MetadataListener::VirusReportingService).to receive(:call)
+      described_class.perform_now(path: path)
+      expect(MetadataListener::VirusReportingService).to have_received(:call).with(
+        path: a_kind_of(String),
+        endpoint: nil,
+        api_token: nil
+      )
+    end
   end
 end

--- a/spec/lib/metadata_listener/s3_client_spec.rb
+++ b/spec/lib/metadata_listener/s3_client_spec.rb
@@ -27,11 +27,10 @@ RSpec.describe MetadataListener::S3Client do
 
     context 'when the file is available in S3' do
       let(:sample_file) { fixture_path.join('1.pdf') }
-
-      let(:file_key) { upload_file(sample_file) }
+      let(:path) { upload_file(file: sample_file) }
 
       it 'downloads the file to a temporary location' do
-        new_file = downloader.download_file(file_key)
+        new_file = downloader.download_file(path)
         expect(Digest::MD5.hexdigest(new_file.body.read)).to eq(Digest::MD5.hexdigest(sample_file.read))
       end
     end

--- a/spec/lib/metadata_listener/virus_reporting_service_spec.rb
+++ b/spec/lib/metadata_listener/virus_reporting_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe MetadataListener::VirusReportingService do
+  let(:mock_logger) { instance_spy('Logger') }
+
+  before do
+    allow(MetadataListener::ClamavService).to receive(:call).and_return(false)
+    allow(MetadataListener).to receive(:logger).and_return(mock_logger)
+  end
+
+  context 'when the file is clean' do
+    it 'logs a success message' do
+      described_class.call(path: 'file_path')
+      expect(mock_logger).to have_received(:info).with('No virus found for file_path')
+    end
+  end
+
+  context 'when the file has a virus' do
+    before { allow(MetadataListener::ClamavService).to receive(:call).and_return(true) }
+
+    it 'logs failure message' do
+      described_class.call(path: 'file_path')
+      expect(mock_logger).to have_received(:fatal).with('!!! Virus FOUND for file_path')
+    end
+  end
+
+  context 'when reporting results', :vcr do
+    it 'sends the results to an endpoint' do
+      described_class.call(
+        path: 'file_path',
+        endpoint: 'https://scholarsphere-4.test/api/v1/metadata/1',
+        api_token: 'xxxxxx'
+      )
+      expect(mock_logger).not_to have_received(:warn)
+    end
+  end
+
+  context 'when unable to report results', :vcr do
+    it 'logs the response from the endpoint' do
+      described_class.call(
+        path: 'file_path',
+        endpoint: 'https://scholarsphere-4.test/api/v1/metadata/1'
+      )
+      expect(mock_logger).to have_received(:warn).with(/^Report failed/)
+    end
+  end
+end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -5,12 +5,13 @@ module SpecHelpers
     Pathname.pwd.join('spec/files')
   end
 
+  # @return [String] path to uploaded file in S3
   # @note Since we're not supporting uploads (yet?) we can access the S3 client via it's private accessor.
-  def upload_file(sample_file)
+  def upload_file(file:)
     client = MetadataListener::S3Client.new.send(:client)
     key = SecureRandom.uuid
-    uploaded_file = sample_file.open do |file|
-      client.put_object(bucket: ENV['AWS_BUCKET'], key: key, body: file)
+    file.open do |body|
+      client.put_object(bucket: ENV['AWS_BUCKET'], key: key, body: body)
     end
     key
   end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+  c.allow_http_connections_when_no_cassette = true
+  c.ignore_localhost = true
+  c.debug_logger = File.open('log/vcr.log', 'w')
+end


### PR DESCRIPTION
Another application can post a `MetadataListener::Job` to the `:metadata` queue and MetadataListsner will pick it up, check for viruses and report the results back to an endpoint.

There is a `VERIFY_CLIENT_SSL` environment option that can be set to false for hosts that don't have fully fledged ssl certs, such as QA or staging servers. It has to be set to false when testing this out locally, but YMMV elsewhere.