### PR TITLE
bin/ml executable

### DIFF
--- a/bin/ml
+++ b/bin/ml
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require 'bundler'
+Bundler.require
+$LOAD_PATH.prepend(Pathname.pwd.join('lib').to_s)
+require 'metadata_listener'
+require 'pry'
+
+Pry.start


### PR DESCRIPTION
Adds an executable that starts a Pry session with all of the metadata-listener code loaded. This is useful when debugging or running commands from inside the container.

Typically, pry is reserved for development environments, but because this is a non-standard kind of application, Pry is really just functioning as a console with nicer features.